### PR TITLE
TSO filtering now occurs before metadata query

### DIFF
--- a/config/cgm_worker/config_areas_mapping.json
+++ b/config/cgm_worker/config_areas_mapping.json
@@ -1,0 +1,380 @@
+[
+  {
+    "area.eic": "10Y1001A1001A39I",
+    "area.code": "EE",
+    "area.name": "Estonia",
+    "party.name": "ELERING",
+    "party.eic": "10X1001A1001A39W",
+    "opdm.shortname": "ee",
+    "opdm.longname": "EE"
+  },
+  {
+    "area.eic": "10Y1001A1001A59C",
+    "area.code": "IE_NI",
+    "area.name": "Ireland/UK (Northern Ireland)",
+    "party.name": "EIRGRID",
+    "party.eic": "10X1001A1001A531",
+    "opdm.shortname": null,
+    "opdm.longname": null
+  },
+  {
+    "area.eic": "10Y1001A1001A990",
+    "area.code": "MD",
+    "area.name": "Moldova",
+    "party.name": "TRANSELECTRICA",
+    "party.eic": "10XRO-TEL------2",
+    "opdm.shortname": null,
+    "opdm.longname": null
+  },
+  {
+    "area.eic": "10Y1001C--000182",
+    "area.code": "UA",
+    "area.name": "Ukraine",
+    "party.name": "UA_IPS",
+    "party.eic": "10X1001C--00001X",
+    "opdm.shortname": null,
+    "opdm.longname": null
+  },
+  {
+    "area.eic": "10Y1001C--00100H",
+    "area.code": "XK",
+    "area.name": "Kosovo",
+    "party.name": "KOSOVA-TSMO",
+    "party.eic": "10XRKS-KOSTT-007",
+    "opdm.shortname": "kostt",
+    "opdm.longname": "KOSTT"
+  },
+  {
+    "area.eic": "10YAL-KESH-----5",
+    "area.code": "AL",
+    "area.name": "Albania",
+    "party.name": "OST",
+    "party.eic": "10XAL-KESH-----J",
+    "opdm.shortname": "al",
+    "opdm.longname": "AL"
+  },
+  {
+    "area.eic": "10YAT-APG------L",
+    "area.code": "AT",
+    "area.name": "Austria",
+    "party.name": "APG",
+    "party.eic": "10XAT-APG------Z",
+    "opdm.shortname": "apg",
+    "opdm.longname": "APG"
+  },
+  {
+    "area.eic": "10YBA-JPCC-----D",
+    "area.code": "BA",
+    "area.name": "Bosnia and Herzegovina",
+    "party.name": "NOSBIH",
+    "party.eic": "10XBA-JPCCZEKC-K",
+    "opdm.shortname": "ba",
+    "opdm.longname": "BA"
+  },
+  {
+    "area.eic": "10YBE----------2",
+    "area.code": "BE",
+    "area.name": "Belgium",
+    "party.name": "ELIA",
+    "party.eic": "10X1001A1001A094",
+    "opdm.shortname": "be",
+    "opdm.longname": "BE"
+  },
+  {
+    "area.eic": "10YCA-BULGARIA-R",
+    "area.code": "BG",
+    "area.name": "Bulgaria",
+    "party.name": "ESO",
+    "party.eic": "10XBG-ESO------A",
+    "opdm.shortname": "bg",
+    "opdm.longname": "BG"
+  },
+  {
+    "area.eic": "10YCH-SWISSGRIDZ",
+    "area.code": "CH",
+    "area.name": "Switzerland",
+    "party.name": "SWISSGRID",
+    "party.eic": "10XCH-SWISSGRIDC",
+    "opdm.shortname": "ch",
+    "opdm.longname": "CH"
+  },
+  {
+    "area.eic": "10YCS-CG-TSO---S",
+    "area.code": "ME",
+    "area.name": "Montenegro",
+    "party.name": "CGES",
+    "party.eic": "10XCS-CG-TSO---5",
+    "opdm.shortname": "cges",
+    "opdm.longname": "CGES"
+  },
+  {
+    "area.eic": "10YCS-SERBIATSOV",
+    "area.code": "RS",
+    "area.name": "Serbia",
+    "party.name": "EMS",
+    "party.eic": "10XCS-SERBIATSO8",
+    "opdm.shortname": "ems",
+    "opdm.longname": "EMS"
+  },
+  {
+    "area.eic": "10YCZ-CEPS-----N",
+    "area.code": "CZ",
+    "area.name": "Czech Republic",
+    "party.name": "CEPS",
+    "party.eic": "10XCZ-CEPS-GRIDE",
+    "opdm.shortname": "ceps",
+    "opdm.longname": "CEPS"
+  },
+  {
+    "area.eic": "10YDE-ENBW-----N",
+    "area.code": "DE-TRANSNETBW",
+    "area.name": "DE_Transnet",
+    "party.name": "D4",
+    "party.eic": "10XDE-ENBW--TNGX",
+    "opdm.shortname": "d4",
+    "opdm.longname": "D4"
+  },
+  {
+    "area.eic": "10YDE-EON------1",
+    "area.code": "DE-TENNET_DE",
+    "area.name": "DE_Tennet",
+    "party.name": "TTG",
+    "party.eic": "10XDE-EON-NETZ-C",
+    "opdm.shortname": "d2",
+    "opdm.longname": "D2"
+  },
+  {
+    "area.eic": "10YDE-RWENET---I",
+    "area.code": "DE-AMPRION-SCHED",
+    "area.name": "DE_Amprion",
+    "party.name": "D7",
+    "party.eic": "10XDE-RWENET---W",
+    "opdm.shortname": "amprion",
+    "opdm.longname": "Amprion"
+  },
+  {
+    "area.eic": "10YDE-VE-------2",
+    "area.code": "DE-50HERTZ",
+    "area.name": "DE_50Hertz",
+    "party.name": "50Hertz",
+    "party.eic": "10XDE-VE-TRANSMK",
+    "opdm.shortname": "50hertz",
+    "opdm.longname": "50Hertz"
+  },
+  {
+    "area.eic": "10YDK-1--------W",
+    "area.code": "DK1",
+    "area.name": "Denmark DK1",
+    "party.name": "DKW",
+    "party.eic": "10X1001A1001A248",
+    "opdm.shortname": "d1",
+    "opdm.longname": "D1"
+  },
+  {
+    "area.eic": "10YDK-2--------M",
+    "area.code": "DK2",
+    "area.name": "Denmark DK2",
+    "party.name": "DKE",
+    "party.eic": "10X1001A1001A248",
+    "opdm.shortname": "dk",
+    "opdm.longname": "DK"
+  },
+  {
+    "area.eic": "10YES-REE------0",
+    "area.code": "ES",
+    "area.name": "Spain",
+    "party.name": "REE",
+    "party.eic": "10XES-REE------E",
+    "opdm.shortname": "es",
+    "opdm.longname": "ES"
+  },
+  {
+    "area.eic": "10YFI-1--------U",
+    "area.code": "FI",
+    "area.name": "Finland",
+    "party.name": "FI",
+    "party.eic": "10X1001A1001A264",
+    "opdm.shortname": "fi",
+    "opdm.longname": "FI"
+  },
+  {
+    "area.eic": "10YFR-RTE------C",
+    "area.code": "FR",
+    "area.name": "France",
+    "party.name": "RTEFRANCE",
+    "party.eic": "10XFR-RTE------Q",
+    "opdm.shortname": "fr",
+    "opdm.longname": "FR"
+  },
+  {
+    "area.eic": "10YGB----------A",
+    "area.code": "GB",
+    "area.name": "United Kingdom",
+    "party.name": "NGET",
+    "party.eic": "10X1001A1001A515",
+    "opdm.shortname": "gb",
+    "opdm.longname": "GB"
+  },
+  {
+    "area.eic": "10YGR-HTSO-----Y",
+    "area.code": "GR",
+    "area.name": "Greece",
+    "party.name": "IPTO",
+    "party.eic": "10XGR-HTSO-----B",
+    "opdm.shortname": "gr",
+    "opdm.longname": "GR"
+  },
+  {
+    "area.eic": "10YHR-HEP------M",
+    "area.code": "HR",
+    "area.name": "Croatia",
+    "party.name": "HOPS",
+    "party.eic": "10XHR-HEP-OPS--A",
+    "opdm.shortname": "hops",
+    "opdm.longname": "HOPS"
+  },
+  {
+    "area.eic": "10YHU-MAVIR----U",
+    "area.code": "HU",
+    "area.name": "Hungary",
+    "party.name": "MAVIR",
+    "party.eic": "10X1001A1001A329",
+    "opdm.shortname": "hu",
+    "opdm.longname": "HU"
+  },
+  {
+    "area.eic": "10YIT-GRTN-----B",
+    "area.code": "IT",
+    "area.name": "Italy",
+    "party.name": "TERNA",
+    "party.eic": "10X1001A1001A345",
+    "opdm.shortname": "it",
+    "opdm.longname": "IT"
+  },
+  {
+    "area.eic": "10YLT-1001A0008Q",
+    "area.code": "LT",
+    "area.name": "Lithuania",
+    "party.name": "LITGRID",
+    "party.eic": "10X1001A1001A55Y",
+    "opdm.shortname": "litgrid",
+    "opdm.longname": "Litgrid"
+  },
+  {
+    "area.eic": "10YLU-CEGEDEL-NQ",
+    "area.code": "LU",
+    "area.name": "Luxembourg",
+    "party.name": "CREOS",
+    "party.eic": "21X000000001333E",
+    "opdm.shortname": "creos",
+    "opdm.longname": "Creos"
+  },
+  {
+    "area.eic": "10YLV-1001A00074",
+    "area.code": "LV",
+    "area.name": "Latvia",
+    "party.name": "AST",
+    "party.eic": "10X1001A1001B54W",
+    "opdm.shortname": "ast",
+    "opdm.longname": "AST"
+  },
+  {
+    "area.eic": "10YMA-ONE------O",
+    "area.code": "MO",
+    "area.name": "Morocco",
+    "party.name": "REE",
+    "party.eic": "10XES-REE------E",
+    "opdm.shortname": null,
+    "opdm.longname": null
+  },
+  {
+    "area.eic": "10YMK-MEPSO----8",
+    "area.code": "MK",
+    "area.name": "Macedonia",
+    "party.name": "MEPSO",
+    "party.eic": "10XMK-MEPSO----M",
+    "opdm.shortname": "mepso",
+    "opdm.longname": "MEPSO"
+  },
+  {
+    "area.eic": "10YNL----------L",
+    "area.code": "NL",
+    "area.name": "Netherlands",
+    "party.name": "TTN",
+    "party.eic": "10X1001A1001A361",
+    "opdm.shortname": "nl",
+    "opdm.longname": "NL"
+  },
+  {
+    "area.eic": "10YNO-0--------C",
+    "area.code": "NO",
+    "area.name": "Norway",
+    "party.name": "STATNETT",
+    "party.eic": "10X1001A1001A38Y",
+    "opdm.shortname": "no",
+    "opdm.longname": "NO"
+  },
+  {
+    "area.eic": "10YPL-AREA-----S",
+    "area.code": "PL",
+    "area.name": "Poland",
+    "party.name": "PSE",
+    "party.eic": "10XPL-TSO------P",
+    "opdm.shortname": "pl",
+    "opdm.longname": "PL"
+  },
+  {
+    "area.eic": "10YPT-REN------W",
+    "area.code": "PT",
+    "area.name": "Portugal",
+    "party.name": "REN",
+    "party.eic": "10XPT-REN------9",
+    "opdm.shortname": "pt",
+    "opdm.longname": "PT"
+  },
+  {
+    "area.eic": "10YRO-TEL------P",
+    "area.code": "RO",
+    "area.name": "Romania",
+    "party.name": "Transelectrica",
+    "party.eic": "10XRO-TEL------2",
+    "opdm.shortname": "ro",
+    "opdm.longname": "RO"
+  },
+  {
+    "area.eic": "10YSE-1--------K",
+    "area.code": "SE",
+    "area.name": "Sweden",
+    "party.name": "SVK",
+    "party.eic": "10X1001A1001A418",
+    "opdm.shortname": "se",
+    "opdm.longname": "SE"
+  },
+  {
+    "area.eic": "10YSI-ELES-----O",
+    "area.code": "SI",
+    "area.name": "Slovenia",
+    "party.name": "ELES",
+    "party.eic": "10XSI-ELES-----1",
+    "opdm.shortname": "eles",
+    "opdm.longname": "ELES"
+  },
+  {
+    "area.eic": "10YSK-SEPS-----K",
+    "area.code": "SK",
+    "area.name": "Slovak Republic",
+    "party.name": "SEPS",
+    "party.eic": "10XSK-SEPS-GRIDB",
+    "opdm.shortname": "seps",
+    "opdm.longname": "SEPS"
+  },
+  {
+    "area.eic": "10YTR-TEIAS----W",
+    "area.code": "TR",
+    "area.name": "Turkey",
+    "party.name": "TEIAS",
+    "party.eic": "10XTR-TEIAS----9",
+    "opdm.shortname": "teias",
+    "opdm.longname": "TEIAS"
+  }
+]

--- a/emf/common/integrations/object_storage/models.py
+++ b/emf/common/integrations/object_storage/models.py
@@ -10,13 +10,17 @@ logger = logging.getLogger(__name__)
 
 def compile_query(metadata: dict, filter: str | None):
 
+    """Creates the query in the correct syntax acceptable by Elastic"""
+
     match_and_term_list = []
     for key, value in metadata.items():
         if isinstance(value, list):
             match_and_term_list.append({"terms": {key: value}})
         else:
             match_and_term_list.append({"match": {key: value}})
-
+    # Looks like the filter was made to handle value ranges not to match by TSO
+    # (and the filter is expected to be the scenario date range specifically)
+    # So the initial desired TSO filter was added to the metadata dict, not the filter
     if filter:
         query = {"bool": {"must": match_and_term_list, "filter": {"range": {"pmd:scenarioDate": {"gte": filter}}}}}
     else:
@@ -205,11 +209,11 @@ def get_latest_boundary():
 def get_latest_models_and_download(time_horizon: str,
                                    scenario_date: str,
                                    valid: bool = True,
-                                   tso: str | None = None,
+                                   tso: list[str] | None = None,     # this used to be str but I don't see how that would work so changed to list
                                    object_type: str = 'IGM',
                                    data_source: str | None = None
                                    ):
-
+    """Gathers the conditions for filtering for the models metadata query, performs the query and returns the metadatas"""
     logger.info(f"Retrieving latest network models of type: {object_type} [source: {data_source}]")
 
     meta = {'pmd:validFrom': f"{parse_datetime(scenario_date):%Y%m%dT%H%MZ}",
@@ -218,7 +222,7 @@ def get_latest_models_and_download(time_horizon: str,
             "data-source": data_source}
 
     if tso:
-        meta['pmd:TSO'] = tso
+        meta['pmd:TSO.keyword'] = tso # but note that this is now a list not a str like the others
 
     if valid:
         meta["valid"] = valid
@@ -256,14 +260,24 @@ if __name__ == "__main__":
                         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                         level=logging.INFO)
 
-    test_query = {"pmd:TSO": "TERNA",
-                  "pmd:timeHorizon": "2D",
-                  "pmd:scenarioDate": "2025-02-15T22:30:00Z",
-                  }
-    test_filter = "now-2w"
+    #test_query = {"pmd:TSO": "TERNA",
+    #              "pmd:timeHorizon": "2D",
+    #              "pmd:scenarioDate": "2026-07-16T22:30:00Z",
+    #              }
+    time_horizon="1D"
+    object_type="IGM"
+    scenario_date = "20260716T1530Z"
+    meta = {'pmd:validFrom': f"{parse_datetime(scenario_date):%Y%m%dT%H%MZ}",
+            'pmd:timeHorizon': time_horizon,
+            'opde:Object-Type': object_type,
+            "data-source": None,
+            "pmd:TSO": ["LITGRID", "AST", "PSE"]}
+
+    test_query = compile_query(meta, filter=None)
+    test_filter = None #"now-2w"
     test_response = query_data(test_query, query_filter=test_filter, return_payload=True)
 
     #models = get_latest_models_and_download("1D", '20240526T1530Z', valid=False)
-    models = get_latest_models_and_download("ID", '20240522T1530Z', valid=True)
-    bds = get_latest_boundary()
+    #models = get_latest_models_and_download("ID", '20260716T1530Z', valid=True)
+    #bds = get_latest_boundary()
     logger.info("Test script finished")

--- a/emf/common/integrations/object_storage/models.py
+++ b/emf/common/integrations/object_storage/models.py
@@ -18,9 +18,6 @@ def compile_query(metadata: dict, filter: str | None):
             match_and_term_list.append({"terms": {key: value}})
         else:
             match_and_term_list.append({"match": {key: value}})
-    # Looks like the filter was made to handle value ranges not to match by TSO
-    # (and the filter is expected to be the scenario date range specifically)
-    # So the initial desired TSO filter was added to the metadata dict, not the filter
     if filter:
         query = {"bool": {"must": match_and_term_list, "filter": {"range": {"pmd:scenarioDate": {"gte": filter}}}}}
     else:
@@ -209,11 +206,13 @@ def get_latest_boundary():
 def get_latest_models_and_download(time_horizon: str,
                                    scenario_date: str,
                                    valid: bool = True,
-                                   tso: list[str] | None = None,     # this used to be str but I don't see how that would work so changed to list
+                                   tso: list[str] | None = None,
                                    object_type: str = 'IGM',
                                    data_source: str | None = None
                                    ):
-    """Gathers the conditions for filtering for the models metadata query, performs the query and returns the metadatas"""
+
+    """Gathers the conditions for filtering for the models metadata query, performs the query and returns the metadata"""
+
     logger.info(f"Retrieving latest network models of type: {object_type} [source: {data_source}]")
 
     meta = {'pmd:validFrom': f"{parse_datetime(scenario_date):%Y%m%dT%H%MZ}",
@@ -222,7 +221,7 @@ def get_latest_models_and_download(time_horizon: str,
             "data-source": data_source}
 
     if tso:
-        meta['pmd:TSO.keyword'] = tso # but note that this is now a list not a str like the others
+        meta['pmd:TSO.keyword'] = tso
 
     if valid:
         meta["valid"] = valid
@@ -259,11 +258,6 @@ if __name__ == "__main__":
     logging.basicConfig(stream=sys.stdout,
                         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                         level=logging.INFO)
-
-    #test_query = {"pmd:TSO": "TERNA",
-    #              "pmd:timeHorizon": "2D",
-    #              "pmd:scenarioDate": "2026-07-16T22:30:00Z",
-    #              }
     time_horizon="1D"
     object_type="IGM"
     scenario_date = "20260716T1530Z"
@@ -277,7 +271,4 @@ if __name__ == "__main__":
     test_filter = None #"now-2w"
     test_response = query_data(test_query, query_filter=test_filter, return_payload=True)
 
-    #models = get_latest_models_and_download("1D", '20240526T1530Z', valid=False)
-    #models = get_latest_models_and_download("ID", '20260716T1530Z', valid=True)
-    #bds = get_latest_boundary()
     logger.info("Test script finished")

--- a/emf/model_merger/merge_functions.py
+++ b/emf/model_merger/merge_functions.py
@@ -441,7 +441,6 @@ def evaluate_trustability(report, properties) -> dict:
 
     return {"trustability": trustability, "untrustability_reason": reason}
 
-
 def filter_models(models: list, included_models: list | str = None, excluded_models: list | str = None, filter_on: str = 'pmd:TSO'):
     """
     Filters the list of models to include or to exclude specific tsos if they are given.
@@ -482,6 +481,41 @@ def filter_models(models: list, included_models: list | str = None, excluded_mod
 
     return filtered_models
 
+def filter_tsos(tsos: list, included_models: list | str = None, excluded_models: list | str = None):
+    """
+    Does the exact same thing as the 'filter_models' function above, just the input is a TSO list instead of
+    a list of already queried model dicts, therefore the filter_on input is not needed.
+    Note that while "filter_models" returns a list of model metadata dicts, this returns list of strings!
+    """
+    included_models = [included_models] if isinstance(included_models, str) else included_models
+    excluded_models = [excluded_models] if isinstance(excluded_models, str) else excluded_models
+
+    if included_models:
+        logger.info(f"Models to be included: {included_models} (pre-metadata-query)")
+    elif excluded_models:
+        logger.info(f"Models to be excluded: {excluded_models} (pre-metadata-query)")
+    else:
+        logger.info(f"Including all available models: {tsos} (pre-metadata-query)")
+        return tsos
+
+    filtered_tsos = []
+
+    for tso in tsos:
+
+        if included_models:
+            if tso not in included_models:
+                logger.info(f"Excluded {tso} (pre-metadata-query)")
+                continue
+
+        elif excluded_models:
+            if tso in excluded_models:
+                logger.info(f"Excluded {tso} (pre-metadata-query)")
+                continue
+
+        logger.info(f"Included {tso} (pre-metadata-query)")
+        filtered_tsos.append(tso)
+
+    return filtered_tsos
 
 def filter_models_by_acnp(models: list, merged_model,  acnp_dict, acnp_threshold, conform_load_factor):
 

--- a/emf/model_merger/merge_functions.py
+++ b/emf/model_merger/merge_functions.py
@@ -441,7 +441,9 @@ def evaluate_trustability(report, properties) -> dict:
 
     return {"trustability": trustability, "untrustability_reason": reason}
 
-def filter_models(models: list, included_models: list | str = None, excluded_models: list | str = None, filter_on: str = 'pmd:TSO'):
+
+def filter_models(tsos: list, included_models: list | str = None, excluded_models: list | str = None):
+
     """
     Filters the list of models to include or to exclude specific tsos if they are given.
     If included is defined, excluded is not used
@@ -451,42 +453,6 @@ def filter_models(models: list, included_models: list | str = None, excluded_mod
     :return updated list of igms
     """
 
-    included_models = [included_models] if isinstance(included_models, str) else included_models
-    excluded_models = [excluded_models] if isinstance(excluded_models, str) else excluded_models
-
-    if included_models:
-        logger.info(f"Models to be included: {included_models}")
-    elif excluded_models:
-        logger.info(f"Models to be excluded: {excluded_models}")
-    else:
-        logger.info(f"Including all available models: {[model['pmd:TSO'] for model in models]}")
-        return models
-
-    filtered_models = []
-
-    for model in models:
-
-        if included_models:
-            if model[filter_on] not in included_models:
-                logger.info(f"Excluded {model[filter_on]}")
-                continue
-
-        elif excluded_models:
-            if model[filter_on] in excluded_models:
-                logger.info(f"Excluded {model[filter_on]}")
-                continue
-
-        logger.info(f"Included {model[filter_on]}")
-        filtered_models.append(model)
-
-    return filtered_models
-
-def filter_tsos(tsos: list, included_models: list | str = None, excluded_models: list | str = None):
-    """
-    Does the exact same thing as the 'filter_models' function above, just the input is a TSO list instead of
-    a list of already queried model dicts, therefore the filter_on input is not needed.
-    Note that while "filter_models" returns a list of model metadata dicts, this returns list of strings!
-    """
     included_models = [included_models] if isinstance(included_models, str) else included_models
     excluded_models = [excluded_models] if isinstance(excluded_models, str) else excluded_models
 
@@ -516,6 +482,7 @@ def filter_tsos(tsos: list, included_models: list | str = None, excluded_models:
         filtered_tsos.append(tso)
 
     return filtered_tsos
+
 
 def filter_models_by_acnp(models: list, merged_model,  acnp_dict, acnp_threshold, conform_load_factor):
 

--- a/emf/model_merger/model_merger.py
+++ b/emf/model_merger/model_merger.py
@@ -34,6 +34,10 @@ logger = logging.getLogger(__name__)
 parse_app_properties(caller_globals=globals(), path=config.paths.cgm_worker.merger)
 executor = ThreadPoolExecutor(max_workers=20)
 
+# Retrieve the list of all TSOs ever
+config_areas_mapping = config.paths.cgm_worker.config_areas_mapping
+tsos_config_json = json.load(config_areas_mapping)
+possible_tsos = [area['party.name'] for area in tsos_config_json if 'party.name' in area]
 
 def async_call(function, callback=None, *args, **kwargs):
     future = executor.submit(function, *args, **kwargs)
@@ -217,28 +221,30 @@ class HandlerMergeModels:
         dc_schedules = query_hvdc_schedules(time_horizon=schedule_time_horizon, scenario_timestamp=schedule_start)
         acnp_dict = calculate_ac_net_position(ac_schedules)
 
-        # Collect valid models from ObjectStorage
-        downloaded_models = get_latest_models_and_download(time_horizon=time_horizon,
-                                                           scenario_date=scenario_datetime,
-                                                           valid=True,
-                                                           data_source='OPDM')
-        latest_boundary = get_latest_boundary()
 
-        # Filter out models that are not to be used in merge
-        models = merge_functions.filter_models(models=downloaded_models,
-                                               included_models=included_models,
-                                               excluded_models=excluded_models,
-                                               filter_on='pmd:TSO')
+        # Create list of only the TSOs that are needed for the merge, to query Elastic only for *their* metadata
+        desired_tsos = merge_functions.filter_tsos(tsos=possible_tsos,
+                                                   included_models=included_models,
+                                                   excluded_models=excluded_models)
+        logger.info(f"Compiled the desired tsos list as {desired_tsos}")
+        # but since that did not take into account local import desired TSOs, have to add those as well:
+        if local_import_models: desired_tsos = desired_tsos+local_import_models
+
+        # Collect valid models from ObjectStorage (this is just the metadata of the models, not the actual zips)
+        models = get_latest_models_and_download(time_horizon=time_horizon,
+                                                scenario_date=scenario_datetime,
+                                                valid=True,
+                                                tso=desired_tsos,
+                                                data_source='OPDM')
+        latest_boundary = get_latest_boundary()
 
         # Get additional models from ObjectStorage if local import is configured
         if local_import_models:
             additional_models = get_latest_models_and_download(time_horizon=time_horizon,
                                                                scenario_date=scenario_datetime,
                                                                valid=True,
+                                                               tso=desired_tsos,
                                                                data_source='PDN')
-            additional_models = merge_functions.filter_models(models=additional_models,
-                                                              included_models=local_import_models,
-                                                              filter_on='pmd:TSO')
 
             additional_tsos = {model['pmd:TSO'] for model in additional_models}
             missing_local_import = [tso for tso in local_import_models if tso not in additional_tsos]
@@ -264,10 +270,8 @@ class HandlerMergeModels:
                 pdn_auto_models = get_latest_models_and_download(time_horizon=time_horizon,
                                                                  scenario_date=scenario_datetime,
                                                                  valid=True,
+                                                                 tso=desired_tsos,
                                                                  data_source='PDN')
-                pdn_auto_models = merge_functions.filter_models(models=pdn_auto_models,
-                                                                included_models=missing_models_rmm,
-                                                                filter_on='pmd:TSO')
 
                 # Cache PDN TSO set
                 pdn_tsos = {m['pmd:TSO'] for m in pdn_auto_models}

--- a/emf/model_merger/model_merger.py
+++ b/emf/model_merger/model_merger.py
@@ -34,10 +34,6 @@ logger = logging.getLogger(__name__)
 parse_app_properties(caller_globals=globals(), path=config.paths.cgm_worker.merger)
 executor = ThreadPoolExecutor(max_workers=20)
 
-# Retrieve the list of all TSOs ever
-config_areas_mapping = config.paths.cgm_worker.config_areas_mapping
-tsos_config_json = json.load(config_areas_mapping)
-possible_tsos = [area['party.name'] for area in tsos_config_json if 'party.name' in area]
 
 def async_call(function, callback=None, *args, **kwargs):
     future = executor.submit(function, *args, **kwargs)
@@ -174,6 +170,11 @@ class HandlerMergeModels:
         # Convert task fields to bool where necessary
         task = convert_dict_str_to_bool(task)
 
+        # Retrieve the list of all TSOs from the configuration file
+        config_areas_mapping = config.paths.cgm_worker.config_areas_mapping
+        tsos_config_json = json.load(config_areas_mapping)
+        full_tso_list = [area['party.name'] for area in tsos_config_json if 'party.name' in area]
+
         # TODO - make it to a wrapper once it is settled/standardized how this info is exchanged
         # Initialize trace
         self.elk_logging_handler.start_trace(task)
@@ -221,14 +222,11 @@ class HandlerMergeModels:
         dc_schedules = query_hvdc_schedules(time_horizon=schedule_time_horizon, scenario_timestamp=schedule_start)
         acnp_dict = calculate_ac_net_position(ac_schedules)
 
-
         # Create list of only the TSOs that are needed for the merge, to query Elastic only for *their* metadata
-        desired_tsos = merge_functions.filter_tsos(tsos=possible_tsos,
+        desired_tsos = merge_functions.filter_models(tsos=full_tso_list,
                                                    included_models=included_models,
                                                    excluded_models=excluded_models)
         logger.info(f"Compiled the desired tsos list as {desired_tsos}")
-        # but since that did not take into account local import desired TSOs, have to add those as well:
-        if local_import_models: desired_tsos = desired_tsos+local_import_models
 
         # Collect valid models from ObjectStorage (this is just the metadata of the models, not the actual zips)
         models = get_latest_models_and_download(time_horizon=time_horizon,
@@ -243,7 +241,7 @@ class HandlerMergeModels:
             additional_models = get_latest_models_and_download(time_horizon=time_horizon,
                                                                scenario_date=scenario_datetime,
                                                                valid=True,
-                                                               tso=desired_tsos,
+                                                               tso=local_import_models,
                                                                data_source='PDN')
 
             additional_tsos = {model['pmd:TSO'] for model in additional_models}
@@ -270,7 +268,7 @@ class HandlerMergeModels:
                 pdn_auto_models = get_latest_models_and_download(time_horizon=time_horizon,
                                                                  scenario_date=scenario_datetime,
                                                                  valid=True,
-                                                                 tso=desired_tsos,
+                                                                 tso=missing_models_rmm,
                                                                  data_source='PDN')
 
                 # Cache PDN TSO set
@@ -659,4 +657,4 @@ if __name__ == "__main__":
     properties.headers = {}
 
     worker = HandlerMergeModels()
-    finished_task = worker.handle(sample_task, {})
+    finished_task = worker.handle(sample_task, properties)


### PR DESCRIPTION
Added the config_areas_mapping.json file for a list of all TSOs to filter

Copied the previous filtering method and reworked it to fit to filter upon that Removed the use of the now redundant filtering method post-metadata-queries but preserved the method itself